### PR TITLE
A few changes to support complex pickle files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-pickle"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Georg Brandl <georg@python.org>"]
 license = "MIT/Apache-2.0"
 description = "A serde-based serialization library for Python's pickle format"

--- a/src/de.rs
+++ b/src/de.rs
@@ -517,18 +517,17 @@ impl<R: Read> Deserializer<R> {
                 }
                 BUILD => {
                     let state = self.pop_resolve()?;
-                    // FIXME: I think a memoized instance should be mutated *in place*, not cloned?
-                    let instance = self.pop_resolve()?;
+                    let top = self.top()?;
 
-                    if let Value::ExtObject(o) = instance {
+                    if let Value::ExtObject(ref mut o) = *top {
                         // instance is already an ExtObject, just overwrite .obj with state
-                        self.stack.push(Value::ExtObject(Box::new(ExtObject { obj: state, ext: o.ext })))
+                        o.obj = state;
                     } else if let Value::Dict(d) = state {
                         // instance is nothing special and state is a plain obj, make a plain new Object
-                        self.stack.push(Value::Object(d));
+                        *top = Value::Object(d);
                     } else {
                         // state is not a plain dict, make a new ExtObject
-                        self.stack.push(Value::ExtObject(Box::new(ExtObject { obj: state, ext: Value::None })))
+                        *top = Value::ExtObject(Box::new(ExtObject { obj: state, ext: Value::None }));
                     }
                 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -45,8 +45,8 @@ enum Global {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ExtObject {
-    obj: Value,
-    ext: Value,
+    obj: Value,  // Dict of ordinary object data (but can be MemoRef, or anything if __getdata__ was used)
+    ext: Value,  // Dict/List/Set data if subclass of dict/list/set, or None otherwise
 }
 
 /// Our intermediate representation of a value.
@@ -62,8 +62,8 @@ struct ExtObject {
 enum Value {
     MemoRef(MemoId),
     Global(Global),
-    Object(Vec<(Value, Value)>),
-    ExtObject(Box<ExtObject>),
+    Object(Vec<(Value, Value)>), // Ordinary obj with attribute dict, eligible for promotion to ExtObject
+    ExtObject(Box<ExtObject>), // Object which does not have a dict as data, and/or was used with dict/list/set-specific data loading operations
     None,
     Bool(bool),
     I64(i64),

--- a/src/de.rs
+++ b/src/de.rs
@@ -437,11 +437,11 @@ impl<R: Read> Deserializer<R> {
                 SETITEM => {
                     let value = self.pop()?;
                     let key = self.pop()?;
-                    self.modify_dict(|dict| dict.push((key, value)), "SETITEM")?;
+                    self.modify_dict(|dict| dict.push((key, value)))?;
                 }
                 SETITEMS => {
                     let items = self.pop_mark()?;
-                    self.modify_dict(|dict| Self::extend_dict(dict, items), "SETITEMS")?;
+                    self.modify_dict(|dict| Self::extend_dict(dict, items))?;
                 }
 
                 // Sets and frozensets
@@ -933,7 +933,7 @@ impl<R: Read> Deserializer<R> {
     }
 
     // Modify the stack-top dict.
-    fn modify_dict<F>(&mut self, f: F, descr: &str) -> Result<()>
+    fn modify_dict<F>(&mut self, f: F) -> Result<()>
         where F: FnOnce(&mut Vec<(Value, Value)>)
     {
         let pos = self.pos;


### PR DESCRIPTION
I was trying to load some pretty non-Rust-friendly pickle files with this crate (using the `Value` API) and, while I've mostly come to the conclusion that this crate is not really built for that, I've made some improvements which might be worth upstreaming. Consider this a request for comments on whether any of this is useful. I can split it up or make changes as needed.

This adds options which enable loading pickle files with recursive data structures (through an option to return a `None` when recursing instead of causing an error) and to support custom subclasses of dict, list, and set.

Custom subclasses of dict, list, and set are detected by looking for dict, list or set operations performed on an object. These objects are returned as a tuple `(object_attributes, superclass_data)` or, if you set an option, the object attributes will be discarded and only the superclass data will be returned. This option makes it possible to mostly treat (e.g.) subclasses of list as just lists, with the caveat that if the list is empty the object's attributes may be returned in the form of a dict instead, as we have no way to detect that an object is a list if no list operations are performed on it.

Each commit should be mostly self-contained, except that the first commit (Decode collections.defaultdict as dict) is reverted and superseded by the commit after that, since the second commit contains a different, more general solution to the same problem. I kept it around in case the more tricky solution is rejected. (Edit: this was true before a number of followup bugfix commits. Instead of rewriting history I've left them as-is, but I can fix that if wanted.)
